### PR TITLE
(#2) Better CA detection

### DIFF
--- a/tasks/clean_cert.rb
+++ b/tasks/clean_cert.rb
@@ -11,8 +11,11 @@ require 'open3'
 
 Puppet.initialize_settings
 
-unless Puppet[:server] == Puppet[:certname]
-  puts 'This task can only be run on the Master (of Masters)'
+# This task only works when running against your Puppet CA server, so let's check for that.
+# In Puppetserver, that means that the bootstrap.cfg file contains 'certificate-authority-service'.
+bootstrap_cfg = '/etc/puppetlabs/puppetserver/bootstrap.cfg'
+if !File.exist?(bootstrap_cfg) || File.readlines(bootstrap_cfg).grep(%r{^[^#].+certificate-authority-service$}).empty?
+  puts 'This task can only be run on your certificate authority Puppet master (MoM)'
   exit 1
 end
 

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -11,8 +11,11 @@ require 'open3'
 
 Puppet.initialize_settings
 
-unless Puppet[:server] == Puppet[:certname]
-  puts 'This task can only be run on the Master (of Masters)'
+# This task only works when running against your Puppet CA server, so let's check for that.
+# In Puppetserver, that means that the bootstrap.cfg file contains 'certificate-authority-service'.
+bootstrap_cfg = '/etc/puppetlabs/puppetserver/bootstrap.cfg'
+if !File.exist?(bootstrap_cfg) || File.readlines(bootstrap_cfg).grep(%r{^[^#].+certificate-authority-service$}).empty?
+  puts 'This task can only be run on your certificate authority Puppet master (MoM)'
   exit 1
 end
 


### PR DESCRIPTION
Fixes issue #2

Prior to this, there was a naive detection of the certificate authority
that failed in certain cases. This resolves that by using a (hopefully)
more stable detection method of looking at Puppetserver's bootstrap.cfg
for the line that enables the CA services.