### PR TITLE
Add ability to supply a JSON array as input

### DIFF
--- a/tasks/clean_cert.json
+++ b/tasks/clean_cert.json
@@ -1,11 +1,11 @@
 {
   "description": "Clean (remove) a Puppet agent's certificate from your Master",
-  "input_method": "environment",
+  "input_method": "stdin",
   "supports_noop": false,
   "parameters": {
     "agent_certnames": {
       "description": "A comma-separated list of agent certificate to clean",
-      "type": "Pattern[/^([A-Za-z0-9._-]+,?)+$/]"
+      "type": "Variant[Pattern[/^([A-Za-z0-9._-]+,?)+$/], Array[Pattern[/^([A-Za-z0-9._-]+,?)+$/]]]"
     }
   }
 }

--- a/tasks/clean_cert.rb
+++ b/tasks/clean_cert.rb
@@ -9,6 +9,7 @@
 require 'puppet'
 require 'open3'
 require 'facter'
+require 'json'
 
 Puppet.initialize_settings
 
@@ -56,7 +57,8 @@ if !targetting_a_ca?
 
 else
 
-  agents = ENV['PT_agent_certnames'].split(',')
+  params = JSON.parse(STDIN.read)
+  agents = params['agent_certnames'].is_a?(Array) ? params['agent_certnames'] : params['agent_certnames'].split(','))
 
   agents.each do |agent|
     results[agent] = {}

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,11 +1,11 @@
 {
   "description": "Purge Puppet agent nodes",
-  "input_method": "environment",
+  "input_method": "stdin",
   "supports_noop": false,
   "parameters": {
     "agent_certnames": {
       "description": "A comma-separated list of agent certificate names",
-      "type": "Pattern[/^([A-Za-z0-9._-]+,?)+$/]"
+      "type": "Variant[Pattern[/^([A-Za-z0-9._-]+,?)+$/], Array[Pattern[/^([A-Za-z0-9._-]+,?)+$/]]]"
     }
   }
 }

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,6 +8,7 @@
 #
 require 'puppet'
 require 'open3'
+require 'json'
 
 Puppet.initialize_settings
 
@@ -40,7 +41,8 @@ if !targetting_a_ca?
 
 else
 
-  agents = ENV['PT_agent_certnames'].split(',')
+  params = JSON.parse(STDIN.read)
+  agents = params['agent_certnames'].is_a?(Array) ? params['agent_certnames'] : params['agent_certnames'].split(',')
 
   agents.each do |agent|
     results[agent] = {}


### PR DESCRIPTION
Adds the ability to allow a user to supply a JSON array as input.

Was also able to implement using `environment` as the input method, but had to use a rescue block to make it happen. Stdin seems cleaner, so went with that.